### PR TITLE
Add React dashboard and receipt detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,12 @@ This project aims to create an accounting software that uses AI to:
 (Instructions to be added later)
 
 ## Contributing
-(Contribution guidelines to be added later) 
+(Contribution guidelines to be added later)
+
+## Frontend Prototype
+
+The `frontend/` directory provides a minimal React prototype loaded via CDN
+scripts. It includes a Dashboard listing receipts from Firestore and a Receipt
+Detail view where the data can be edited and posted to Fiken. Configure
+`frontend/firebaseConfig.js` with your Firebase project settings and then open
+`frontend/index.html` in a browser to try it out.

--- a/docs/firestore_schema.md
+++ b/docs/firestore_schema.md
@@ -1,0 +1,53 @@
+# Firestore Database Schema
+
+This document outlines the initial Firestore collections for the project. These structures are designed around the Fiken API integration requirements.
+
+## Collections
+
+### 1. `users`
+Stores user information and authentication details.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | `string` | User's email address. |
+| `displayName` | `string` | Optional user-friendly name. |
+| `fikenAccessToken` | `string` | OAuth token for Fiken API access. |
+| `fikenRefreshToken` | `string` | OAuth refresh token. |
+| `createdAt` | `timestamp` | When the user was created. |
+| `updatedAt` | `timestamp` | Last time the record was updated. |
+
+### 2. `receipts`
+Metadata about uploaded receipts and their processing status.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who uploaded the receipt. |
+| `filePath` | `string` | Location of the file in storage. |
+| `vendor` | `string` | Vendor extracted from the receipt. |
+| `date` | `timestamp` | Date of the receipt. |
+| `totalAmount` | `number` | Total amount on the receipt. |
+| `currency` | `string` | Currency code (e.g., `NOK`, `USD`). |
+| `status` | `string` | Processing state: `pending_ocr`, `pending_review`, `posted_to_fiken`, etc. |
+| `extractedData` | `map` | Raw OCR results or parsed fields. |
+| `createdAt` | `timestamp` | When the receipt was uploaded. |
+| `updatedAt` | `timestamp` | Last update time. |
+
+### 3. `rules`
+Custom categorization rules for mapping receipts to accounts or Fiken categories.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who owns the rule. |
+| `matchVendor` | `string` | Vendor name or pattern to match. |
+| `account` | `integer` | Accounting account to assign. |
+| `vatType` | `string` | VAT category (e.g., `HIGH`, `LOW`). |
+| `description` | `string` | Optional explanation of the rule. |
+| `createdAt` | `timestamp` | When the rule was created. |
+| `updatedAt` | `timestamp` | When the rule was last modified. |
+
+## Status Values for Receipts
+- `pending_ocr`: Receipt image uploaded but waiting for OCR processing.
+- `pending_review`: Data extracted; user needs to confirm before posting.
+- `posted_to_fiken`: Receipt has been sent to Fiken as an expense or supplier invoice.
+
+These collections provide a starting point for managing users, receipts, and categorization logic in Firestore. They align with the data required for interacting with the Fiken API.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,157 @@
+const { useState, useEffect } = React;
+
+const db = firebase.firestore();
+const storage = firebase.storage();
+
+function App() {
+  const [view, setView] = useState('dashboard');
+  const [selectedId, setSelectedId] = useState(null);
+
+  return (
+    <div>
+      {view === 'dashboard' && (
+        <Dashboard onSelect={(id) => { setSelectedId(id); setView('detail'); }} />
+      )}
+      {view === 'detail' && (
+        <ReceiptDetail receiptId={selectedId} onBack={() => setView('dashboard')} />
+      )}
+    </div>
+  );
+}
+
+function Dashboard({ onSelect }) {
+  const [receipts, setReceipts] = useState([]);
+
+  useEffect(() => {
+    const user = firebase.auth().currentUser;
+    if (!user) return;
+    const unsubscribe = db.collection('receipts')
+      .where('userId', '==', user.uid)
+      .onSnapshot((snap) => {
+        const items = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setReceipts(items);
+      });
+    return unsubscribe;
+  }, []);
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <table className="min-w-full bg-white border">
+        <thead>
+          <tr>
+            <th className="border px-2 py-1">Vendor</th>
+            <th className="border px-2 py-1">Date</th>
+            <th className="border px-2 py-1">Amount</th>
+            <th className="border px-2 py-1">Status</th>
+            <th className="border px-2 py-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {receipts.map((r) => (
+            <tr key={r.id}>
+              <td className="border px-2 py-1">{r.vendor || '-'}</td>
+              <td className="border px-2 py-1">
+                {r.date ? new Date(r.date.seconds * 1000).toLocaleDateString() : '-'}
+              </td>
+              <td className="border px-2 py-1">{r.totalAmount || '-'}</td>
+              <td className="border px-2 py-1">{r.status || '-'}</td>
+              <td className="border px-2 py-1">
+                <button className="text-blue-600 underline" onClick={() => onSelect(r.id)}>
+                  View
+                </button>
+              </td>
+            </tr>
+          ))}
+          {receipts.length === 0 && (
+            <tr>
+              <td colSpan="5" className="border px-2 py-1 text-center text-gray-500">
+                No receipts found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ReceiptDetail({ receiptId, onBack }) {
+  const [receipt, setReceipt] = useState(null);
+  const [imageUrl, setImageUrl] = useState('');
+  const [form, setForm] = useState({ vendor: '', date: '', totalAmount: '' });
+  const [posting, setPosting] = useState(false);
+
+  useEffect(() => {
+    if (!receiptId) return;
+    const unsub = db.collection('receipts').doc(receiptId).onSnapshot(async (doc) => {
+      const data = { id: doc.id, ...doc.data() };
+      setReceipt(data);
+      setForm({
+        vendor: data.vendor || '',
+        date: data.date ? new Date(data.date.seconds * 1000).toISOString().substr(0,10) : '',
+        totalAmount: data.totalAmount || ''
+      });
+      if (data.filePath) {
+        try {
+          const url = await storage.ref(data.filePath).getDownloadURL();
+          setImageUrl(url);
+        } catch (e) {
+          console.error('Failed to load image', e);
+        }
+      }
+    });
+    return unsub;
+  }, [receiptId]);
+
+  const updateForm = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const postToFiken = async () => {
+    setPosting(true);
+    try {
+      await db.collection('receipts').doc(receiptId).update({
+        vendor: form.vendor,
+        date: form.date ? new Date(form.date) : null,
+        totalAmount: parseFloat(form.totalAmount) || null
+      });
+      await fetch(`/api/receipts/${receiptId}/post_to_fiken`, { method: 'POST' });
+      alert('Posted to Fiken');
+    } catch (err) {
+      console.error(err);
+      alert('Failed to post to Fiken');
+    }
+    setPosting(false);
+  };
+
+  if (!receipt) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <button className="text-blue-600 underline mb-4" onClick={onBack}>&larr; Back</button>
+      <h2 className="text-xl font-semibold mb-2">Receipt Detail</h2>
+      {imageUrl && <img src={imageUrl} alt="Receipt" className="mb-4 max-w-xs" />}
+      <div className="space-y-2">
+        <div>
+          <label className="block">Vendor</label>
+          <input type="text" name="vendor" value={form.vendor} onChange={updateForm} className="border p-1 w-full" />
+        </div>
+        <div>
+          <label className="block">Date</label>
+          <input type="date" name="date" value={form.date} onChange={updateForm} className="border p-1 w-full" />
+        </div>
+        <div>
+          <label className="block">Total Amount</label>
+          <input type="number" step="0.01" name="totalAmount" value={form.totalAmount} onChange={updateForm} className="border p-1 w-full" />
+        </div>
+        <button className="bg-green-600 text-white px-4 py-2 rounded" onClick={postToFiken} disabled={posting}>
+          {posting ? 'Posting...' : 'Post to Fiken'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/firebaseConfig.js
+++ b/frontend/firebaseConfig.js
@@ -1,0 +1,11 @@
+// Replace the configuration below with your Firebase project's details.
+var firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+firebase.initializeApp(firebaseConfig);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Accounting Genie Frontend</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <!-- Firebase v8 for easier CDN usage -->
+  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-storage.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script src="firebaseConfig.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root" class="p-4"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple React-based dashboard listing receipts from Firestore
- add a receipt detail view to edit data and post to Fiken
- provide firebase config placeholder and HTML entry point
- document how to launch the prototype in README

## Testing
- `pytest -q` *(fails: command not found)*