### PR TITLE
Add FastAPI prototype with config UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # AI-Powered Accounting Genie
 
-This project aims to create an accounting software that uses AI to:
-1.  Go through accounting data.
-2.  Organize files and data.
-3.  Generate reports.
+This project aims to create a simple prototype for uploading receipt images or PDF files and eventually sending them to Fiken. The prototype exposes a small FastAPI server with a minimal user interface.
 
-## Features (Planned)
-- Automated data ingestion from various sources (e.g., CSVs, bank statements).
-- AI-powered transaction categorization.
-- Intelligent file organization.
-- Customizable report generation.
-- Insights and anomaly detection.
+## Features (Prototype)
+- Basic configuration UI for storing Fiken API keys and an OpenAI API key.
+- Endpoint to generate the redirect URL used in the Fiken OAuth setup.
+- Placeholder endpoint for uploading receipt files.
+- Windows `run.bat` script for launching the server quickly.
 
-## Getting Started
-(Instructions to be added later)
+## Running
+1. Install the dependencies (FastAPI and Uvicorn). In many Python environments these are available already, but you can install them with:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Double-click `run.bat` (on Windows) or run the equivalent command on other platforms:
+   ```bash
+   python -m uvicorn main:app --reload
+   ```
+3. Open `http://localhost:8000/` in your browser. Use the form to enter your Fiken `client_id`, `client_secret`, and OpenAI API key. The page also displays the redirect URL you must register in the Fiken developer settings.
 
-## Contributing
-(Contribution guidelines to be added later) 
+The current implementation only saves the configuration locally and accepts uploads. Actual calls to Fiken or OpenAI are left as TODOs.
+
+## Firestore Schema
+See `docs/firestore_schema.md` for an outline of the planned Firestore collections.

--- a/docs/firestore_schema.md
+++ b/docs/firestore_schema.md
@@ -1,0 +1,53 @@
+# Firestore Database Schema
+
+This document outlines the initial Firestore collections for the project. These structures are designed around the Fiken API integration requirements.
+
+## Collections
+
+### 1. `users`
+Stores user information and authentication details.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | `string` | User's email address. |
+| `displayName` | `string` | Optional user-friendly name. |
+| `fikenAccessToken` | `string` | OAuth token for Fiken API access. |
+| `fikenRefreshToken` | `string` | OAuth refresh token. |
+| `createdAt` | `timestamp` | When the user was created. |
+| `updatedAt` | `timestamp` | Last time the record was updated. |
+
+### 2. `receipts`
+Metadata about uploaded receipts and their processing status.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who uploaded the receipt. |
+| `filePath` | `string` | Location of the file in storage. |
+| `vendor` | `string` | Vendor extracted from the receipt. |
+| `date` | `timestamp` | Date of the receipt. |
+| `totalAmount` | `number` | Total amount on the receipt. |
+| `currency` | `string` | Currency code (e.g., `NOK`, `USD`). |
+| `status` | `string` | Processing state: `pending_ocr`, `pending_review`, `posted_to_fiken`, etc. |
+| `extractedData` | `map` | Raw OCR results or parsed fields. |
+| `createdAt` | `timestamp` | When the receipt was uploaded. |
+| `updatedAt` | `timestamp` | Last update time. |
+
+### 3. `rules`
+Custom categorization rules for mapping receipts to accounts or Fiken categories.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who owns the rule. |
+| `matchVendor` | `string` | Vendor name or pattern to match. |
+| `account` | `integer` | Accounting account to assign. |
+| `vatType` | `string` | VAT category (e.g., `HIGH`, `LOW`). |
+| `description` | `string` | Optional explanation of the rule. |
+| `createdAt` | `timestamp` | When the rule was created. |
+| `updatedAt` | `timestamp` | When the rule was last modified. |
+
+## Status Values for Receipts
+- `pending_ocr`: Receipt image uploaded but waiting for OCR processing.
+- `pending_review`: Data extracted; user needs to confirm before posting.
+- `posted_to_fiken`: Receipt has been sent to Fiken as an expense or supplier invoice.
+
+These collections provide a starting point for managing users, receipts, and categorization logic in Firestore. They align with the data required for interacting with the Fiken API.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Accounting Genie Setup</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        label { display: block; margin-bottom: 0.5em; }
+        input { width: 300px; }
+    </style>
+    <script>
+        async function loadConfig() {
+            const res = await fetch('/api/config');
+            if (res.ok) {
+                const cfg = await res.json();
+                document.getElementById('clientId').value = cfg.fikenClientId || '';
+                document.getElementById('clientSecret').value = cfg.fikenClientSecret || '';
+                document.getElementById('openaiKey').value = cfg.openaiKey || '';
+            }
+        }
+        async function saveConfig() {
+            const cfg = {
+                fikenClientId: document.getElementById('clientId').value,
+                fikenClientSecret: document.getElementById('clientSecret').value,
+                openaiKey: document.getElementById('openaiKey').value
+            };
+            await fetch('/api/config', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(cfg)
+            });
+            alert('Configuration saved');
+        }
+        async function showRedirectUrl() {
+            const res = await fetch('/api/redirect-url');
+            if (res.ok) {
+                const data = await res.json();
+                document.getElementById('redirectUrl').textContent = data.redirectUrl;
+            }
+        }
+        window.onload = function() {
+            loadConfig();
+            showRedirectUrl();
+        };
+    </script>
+</head>
+<body>
+    <h1>Accounting Genie Setup</h1>
+    <label>Fiken Client ID<br><input id="clientId"></label>
+    <label>Fiken Client Secret<br><input id="clientSecret"></label>
+    <label>OpenAI API Key<br><input id="openaiKey"></label>
+    <button onclick="saveConfig()">Save Configuration</button>
+    <p>Redirect URL for Fiken OAuth: <span id="redirectUrl"></span></p>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -1,5 +1,71 @@
-def main():
-    print("AI Accounting Genie is running!")
+import json
+import os
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, UploadFile, File, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+CONFIG_PATH = Path('config.json')
+UPLOAD_DIR = Path('uploads')
+
+app = FastAPI(title="Accounting Genie")
+app.mount("/static", StaticFiles(directory="frontend"), name="static")
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with CONFIG_PATH.open('r') as f:
+            return json.load(f)
+    return {"fikenClientId": "", "fikenClientSecret": "", "openaiKey": ""}
+
+
+def save_config(cfg: dict):
+    with CONFIG_PATH.open('w') as f:
+        json.dump(cfg, f)
+
+
+@app.get("/")
+def index():
+    return FileResponse('frontend/index.html')
+
+
+@app.get("/api/config")
+def get_config():
+    cfg = load_config()
+    return cfg
+
+
+@app.post("/api/config")
+async def set_config(cfg: dict):
+    save_config(cfg)
+    return {"status": "saved"}
+
+
+@app.get("/api/redirect-url")
+def get_redirect_url(request: Request):
+    url = str(request.url_for('fiken_callback'))
+    return {"redirectUrl": url}
+
+
+@app.get("/api/callback")
+def fiken_callback(code: Optional[str] = None):
+    # TODO: Exchange code for tokens and store them
+    return {"received_code": code}
+
+
+@app.post("/api/upload")
+async def upload_receipt(file: UploadFile = File(...)):
+    UPLOAD_DIR.mkdir(exist_ok=True)
+    dest = UPLOAD_DIR / file.filename
+    with dest.open('wb') as f:
+        f.write(await file.read())
+
+    # TODO: Send image/PDF to OpenAI for analysis and post to Fiken
+    return {"status": "uploaded", "filename": file.filename}
+
 
 if __name__ == "__main__":
-    main() 
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
- 
+fastapi
+uvicorn

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Launch Accounting Genie FastAPI server
+python -m uvicorn main:app --reload
+pause


### PR DESCRIPTION
## Summary
- implement a small FastAPI app that serves a config form
- allow storing Fiken and OpenAI keys in `config.json`
- provide endpoint to show the Fiken OAuth redirect URL
- add a Windows `run.bat` helper
- document how to run the prototype

## Testing
- `pytest -q` *(fails: command not found)*