### PR TITLE
Add initial Fiken prototype backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
 # AI-Powered Accounting Genie
 
-This project aims to create an accounting software that uses AI to:
-1.  Go through accounting data.
-2.  Organize files and data.
-3.  Generate reports.
+This prototype demonstrates a minimal workflow for uploading receipts,
+processing them with AI, and creating Fiken expenses. It is **not** a
+finished product but shows the basic pieces required.
 
-## Features (Planned)
-- Automated data ingestion from various sources (e.g., CSVs, bank statements).
-- AI-powered transaction categorization.
-- Intelligent file organization.
-- Customizable report generation.
-- Insights and anomaly detection.
+## Features
+- Upload receipt images which are stored in Firebase Storage
+- Placeholder OCR/AI extraction using OpenAI
+- OAuth2 flow for obtaining Fiken access tokens
+- Endpoint to create an expense in Fiken
 
-## Getting Started
-(Instructions to be added later)
+## Setup
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide a Firebase service account JSON and set the environment variable
+   `GOOGLE_APPLICATION_CREDENTIALS` to its path. Also set
+   `FIREBASE_STORAGE_BUCKET` with your Firebase Storage bucket name.
+3. Set Fiken credentials and redirect URL via environment variables:
+   `FIKEN_CLIENT_ID`, `FIKEN_CLIENT_SECRET`, `FIKEN_REDIRECT_URI`, and
+   `FIKEN_COMPANY` (company slug).
+4. Optionally, set `OPENAI_API_KEY` for AI extraction.
 
-## Contributing
-(Contribution guidelines to be added later) 
+## Running
+Use the `run.bat` script on Windows or run Uvicorn manually:
+```bash
+python -m uvicorn backend.main:app --reload
+```
+The server exposes endpoints under `http://localhost:8000`.
+
+## Status
+This repository only contains a thin demo. Functions such as OCR parsing,
+OpenAI integration, and Fiken API calls are simplified. Further development
+is required before it can be used in production.

--- a/backend/fiken.py
+++ b/backend/fiken.py
@@ -1,0 +1,45 @@
+import os
+import httpx
+
+FIKEN_BASE = "https://api.fiken.no"
+CLIENT_ID = os.environ.get("FIKEN_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("FIKEN_CLIENT_SECRET")
+REDIRECT_URI = os.environ.get("FIKEN_REDIRECT_URI")
+COMPANY_SLUG = os.environ.get("FIKEN_COMPANY")
+
+
+def get_auth_url():
+    params = {
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": "fiken:write",
+    }
+    return f"{FIKEN_BASE}/oauth/authorize?" + httpx.QueryParams(params).encode()
+
+
+async def exchange_code(code: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{FIKEN_BASE}/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": REDIRECT_URI,
+                "client_id": CLIENT_ID,
+                "client_secret": CLIENT_SECRET,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def create_expense(data: dict, access_token: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{FIKEN_BASE}/api/v2/companies/{COMPANY_SLUG}/expenses",
+            json=data,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        resp.raise_for_status()
+        return resp.json()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,67 @@
+import os
+import uuid
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException
+from fastapi.responses import RedirectResponse
+import firebase_admin
+from firebase_admin import credentials, firestore, storage
+from . import fiken, ocr
+
+app = FastAPI()
+
+if not firebase_admin._apps:
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if cred_path:
+        cred = credentials.Certificate(cred_path)
+        firebase_admin.initialize_app(cred, {
+            "storageBucket": os.environ.get("FIREBASE_STORAGE_BUCKET")
+        })
+    else:
+        raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS not set")
+
+_db = firestore.client()
+_bucket = storage.bucket()
+
+
+@app.get("/")
+def root():
+    return {"status": "running"}
+
+
+@app.get("/api/fiken/login")
+def fiken_login():
+    return RedirectResponse(fiken.get_auth_url())
+
+
+@app.get("/api/fiken/callback")
+async def fiken_callback(code: str):
+    tokens = await fiken.exchange_code(code)
+    # In a real app, store tokens linked to the authenticated user
+    return tokens
+
+
+@app.post("/api/receipts")
+async def upload_receipt(file: UploadFile = File(...), user_id: str = Form(...)):
+    receipt_id = str(uuid.uuid4())
+    blob = _bucket.blob(f"receipts/{receipt_id}/{file.filename}")
+    blob.upload_from_file(file.file)
+    blob.make_public()
+    doc = {
+        "userId": user_id,
+        "filePath": blob.public_url,
+        "status": "pending_ocr",
+    }
+    _db.collection("receipts").document(receipt_id).set(doc)
+    ocr.extract_and_update(receipt_id, doc["filePath"])
+    return {"receipt_id": receipt_id}
+
+
+@app.post("/api/receipts/{receipt_id}/post_to_fiken")
+async def post_to_fiken(receipt_id: str, access_token: str = Form(...)):
+    doc_ref = _db.collection("receipts").document(receipt_id)
+    snap = doc_ref.get()
+    if not snap.exists:
+        raise HTTPException(status_code=404, detail="Receipt not found")
+    expense = ocr.prepare_fiken_expense(snap.to_dict())
+    await fiken.create_expense(expense, access_token)
+    doc_ref.update({"status": "posted_to_fiken"})
+    return {"status": "posted"}

--- a/backend/ocr.py
+++ b/backend/ocr.py
@@ -1,0 +1,42 @@
+import json
+import openai
+from firebase_admin import firestore
+
+openai.api_key = openai.api_key or ''
+
+db = firestore.client()
+
+def extract_and_update(receipt_id: str, file_url: str):
+    """Placeholder OCR and AI extraction."""
+    raw_text = "Sample OCR text"  # Replace with call to OCR service
+    doc_ref = db.collection("receipts").document(receipt_id)
+    doc_ref.update({"rawText": raw_text})
+
+    prompt = (
+        "Extract vendor, date and total amount from this receipt text. "
+        "Respond in JSON with fields vendor, date, totalAmount.\n\n" + raw_text
+    )
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        extracted = json.loads(resp.choices[0].message["content"])
+    except Exception:
+        extracted = {}
+
+    doc_ref.update({"extractedData": extracted, "status": "pending_review"})
+    return extracted
+
+
+def prepare_fiken_expense(receipt_data: dict) -> dict:
+    data = receipt_data.get("extractedData", {})
+    return {
+        "date": data.get("date"),
+        "amount": data.get("totalAmount"),
+        "description": data.get("vendor"),
+        "vatType": "HIGH",
+        "account": 6300,
+        "vatIncluded": True,
+        "supplierName": data.get("vendor"),
+    }

--- a/docs/firestore_schema.md
+++ b/docs/firestore_schema.md
@@ -1,0 +1,53 @@
+# Firestore Database Schema
+
+This document outlines the initial Firestore collections for the project. These structures are designed around the Fiken API integration requirements.
+
+## Collections
+
+### 1. `users`
+Stores user information and authentication details.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `email` | `string` | User's email address. |
+| `displayName` | `string` | Optional user-friendly name. |
+| `fikenAccessToken` | `string` | OAuth token for Fiken API access. |
+| `fikenRefreshToken` | `string` | OAuth refresh token. |
+| `createdAt` | `timestamp` | When the user was created. |
+| `updatedAt` | `timestamp` | Last time the record was updated. |
+
+### 2. `receipts`
+Metadata about uploaded receipts and their processing status.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who uploaded the receipt. |
+| `filePath` | `string` | Location of the file in storage. |
+| `vendor` | `string` | Vendor extracted from the receipt. |
+| `date` | `timestamp` | Date of the receipt. |
+| `totalAmount` | `number` | Total amount on the receipt. |
+| `currency` | `string` | Currency code (e.g., `NOK`, `USD`). |
+| `status` | `string` | Processing state: `pending_ocr`, `pending_review`, `posted_to_fiken`, etc. |
+| `extractedData` | `map` | Raw OCR results or parsed fields. |
+| `createdAt` | `timestamp` | When the receipt was uploaded. |
+| `updatedAt` | `timestamp` | Last update time. |
+
+### 3. `rules`
+Custom categorization rules for mapping receipts to accounts or Fiken categories.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `userId` | `reference` | Reference to the user who owns the rule. |
+| `matchVendor` | `string` | Vendor name or pattern to match. |
+| `account` | `integer` | Accounting account to assign. |
+| `vatType` | `string` | VAT category (e.g., `HIGH`, `LOW`). |
+| `description` | `string` | Optional explanation of the rule. |
+| `createdAt` | `timestamp` | When the rule was created. |
+| `updatedAt` | `timestamp` | When the rule was last modified. |
+
+## Status Values for Receipts
+- `pending_ocr`: Receipt image uploaded but waiting for OCR processing.
+- `pending_review`: Data extracted; user needs to confirm before posting.
+- `posted_to_fiken`: Receipt has been sent to Fiken as an expense or supplier invoice.
+
+These collections provide a starting point for managing users, receipts, and categorization logic in Firestore. They align with the data required for interacting with the Fiken API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
- 
+fastapi
+uvicorn
+httpx
+firebase-admin
+google-cloud-firestore
+python-multipart
+openai

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,2 @@
+@echo off
+python -m uvicorn backend.main:app --reload --host 127.0.0.1 --port 8000


### PR DESCRIPTION
## Summary
- add prototype FastAPI backend for uploading receipts
- stub out Fiken OAuth2 and expense API client
- include placeholder OCR/AI extraction
- document setup and add a Windows run script

## Testing
- `pytest -q` *(fails: command not found)*